### PR TITLE
volume steps: lollipop implementation [2/2]

### DIFF
--- a/res/values/custom_strings.xml
+++ b/res/values/custom_strings.xml
@@ -1084,5 +1084,30 @@
     <string name="app_notification_show_on_keyguard_summary">Show notifications from this app on the lockscreen</string>
     <string name="app_notification_no_ongoing_on_keyguard_title">Disable ongoing on lockscreen</string>
     <string name="app_notification_no_ongoing_on_keyguard_summary">Never show ongoing notifications from this app on the lockscreen</string>
+
+    <!-- Volume Steps -->
+    <string name="volume_steps_60">60</string>
+    <string name="volume_steps_45">45</string>
+    <string name="volume_steps_30">30</string>
+    <string name="volume_steps_15">15</string>
+    <string name="volume_steps_7">7</string>
+    <string name="volume_steps_5">5</string>
+
+    <!-- Volume step options. -->
+    <string name="volume_steps_title">Volume steps</string>
+    <!-- Sound settings screen, setting option name -->
+    <string name="volume_steps_alarm_title">Volume steps: Alarm</string>
+    <!-- Sound settings screen, setting option name -->
+    <string name="volume_steps_dtmf_title">Volume steps: DTMF</string>
+    <!-- Sound settings screen, setting option name -->
+    <string name="volume_steps_music_title">Volume steps: Music</string>
+    <!-- Sound settings screen, setting option name -->
+    <string name="volume_steps_notification_title">Volume steps: Notification</string>
+    <!-- Sound settings screen, setting option name -->
+    <string name="volume_steps_ring_title">Volume steps: Ringer</string>
+    <!-- Sound settings screen, setting option name -->
+    <string name="volume_steps_system_title">Volume steps: System</string>
+    <!-- Sound settings screen, setting option name -->
+    <string name="volume_steps_voice_call_title">Volume steps: Voice Call</string>
     
 </resources>

--- a/res/xml/other_sound_settings.xml
+++ b/res/xml/other_sound_settings.xml
@@ -71,4 +71,49 @@
             android:title="@string/emergency_tone_title"
             android:persistent="false" />
 
+    <PreferenceCategory
+            android:title="@string/volume_steps_title"/>
+
+    <!-- Volume steps: Alarm -->
+    <com.android.settings.notification.DropDownPreference
+            android:key="volume_steps_alarm"
+            android:title="@string/volume_steps_alarm_title"
+            android:persistent="false" />
+
+    <!-- Volume steps: DTMF -->
+    <com.android.settings.notification.DropDownPreference
+            android:key="volume_steps_dtmf"
+            android:title="@string/volume_steps_dtmf_title"
+            android:persistent="false" />
+
+    <!-- Volume steps: Music -->
+    <com.android.settings.notification.DropDownPreference
+            android:key="volume_steps_music"
+            android:title="@string/volume_steps_music_title"
+            android:persistent="false" />
+
+    <!-- Volume steps: Notification -->
+    <com.android.settings.notification.DropDownPreference
+            android:key="volume_steps_notification"
+            android:title="@string/volume_steps_notification_title"
+            android:persistent="false" />
+
+    <!-- Volume steps: Ringer -->
+    <com.android.settings.notification.DropDownPreference
+            android:key="volume_steps_ring"
+            android:title="@string/volume_steps_ring_title"
+            android:persistent="false" />
+
+    <!-- Volume steps: System -->
+    <com.android.settings.notification.DropDownPreference
+            android:key="volume_steps_system"
+            android:title="@string/volume_steps_system_title"
+            android:persistent="false" />
+
+    <!-- Volume steps: Voice Call -->
+    <com.android.settings.notification.DropDownPreference
+            android:key="volume_steps_voice_call"
+            android:title="@string/volume_steps_voice_call_title"
+            android:persistent="false" />
+
 </PreferenceScreen>

--- a/src/com/android/settings/notification/OtherSoundSettings.java
+++ b/src/com/android/settings/notification/OtherSoundSettings.java
@@ -32,6 +32,7 @@ import android.provider.SearchIndexableResource;
 import android.provider.Settings.Global;
 import android.provider.Settings.System;
 import android.telephony.TelephonyManager;
+import android.util.Log;
 
 import com.android.settings.R;
 import com.android.settings.SettingsPreferenceFragment;
@@ -57,6 +58,13 @@ public class OtherSoundSettings extends SettingsPreferenceFragment implements In
     private static final int DOCK_AUDIO_MEDIA_ENABLED = 1;
     private static final int DEFAULT_DOCK_AUDIO_MEDIA = DOCK_AUDIO_MEDIA_DISABLED;
 
+    private static final int VOLUME_STEPS_5 = 0;
+    private static final int VOLUME_STEPS_7 = 1;
+    private static final int VOLUME_STEPS_15 = 2;
+    private static final int VOLUME_STEPS_30 = 3;
+    private static final int VOLUME_STEPS_45 = 4;
+    private static final int VOLUME_STEPS_60 = 5;
+
     private static final String KEY_DIAL_PAD_TONES = "dial_pad_tones";
     private static final String KEY_SCREEN_LOCKING_SOUNDS = "screen_locking_sounds";
     private static final String KEY_DOCKING_SOUNDS = "docking_sounds";
@@ -64,6 +72,14 @@ public class OtherSoundSettings extends SettingsPreferenceFragment implements In
     private static final String KEY_VIBRATE_ON_TOUCH = "vibrate_on_touch";
     private static final String KEY_DOCK_AUDIO_MEDIA = "dock_audio_media";
     private static final String KEY_EMERGENCY_TONE = "emergency_tone";
+
+    private static final String KEY_VOLUME_STEPS_ALARM = "volume_steps_alarm";
+    private static final String KEY_VOLUME_STEPS_DTMF = "volume_steps_dtmf";
+    private static final String KEY_VOLUME_STEPS_MUSIC = "volume_steps_music";
+    private static final String KEY_VOLUME_STEPS_NOTIFICATION = "volume_steps_notification";
+    private static final String KEY_VOLUME_STEPS_RING = "volume_steps_ring";
+    private static final String KEY_VOLUME_STEPS_SYSTEM = "volume_steps_system";
+    private static final String KEY_VOLUME_STEPS_VOICE_CALL = "volume_steps_voice_call";
 
     private static final SettingPref PREF_DIAL_PAD_TONES = new SettingPref(
             TYPE_SYSTEM, KEY_DIAL_PAD_TONES, System.DTMF_TONE_WHEN_DIALING, DEFAULT_ON) {
@@ -151,6 +167,160 @@ public class OtherSoundSettings extends SettingsPreferenceFragment implements In
         }
     };
 
+    private static final SettingPref PREF_VOLUME_STEPS_ALARM = new SettingPref(
+            TYPE_SYSTEM, KEY_VOLUME_STEPS_ALARM, System.VOLUME_STEPS_ALARM,
+            VOLUME_STEPS_7,
+            VOLUME_STEPS_5, VOLUME_STEPS_7, VOLUME_STEPS_15,
+            VOLUME_STEPS_30, VOLUME_STEPS_45, VOLUME_STEPS_60) {
+        @Override
+        protected String getCaption(Resources res, int value) {
+            return volStepsCaption(res, value);
+        }
+
+        @Override
+        public void update(Context context) {
+            super.update(context);
+            final int steps = getInt(mType,
+                    context.getContentResolver(), mSetting, mDefault);
+            AudioManager audioManager = (AudioManager)
+                    context.getSystemService(Context.AUDIO_SERVICE);
+            updateVolumeSteps(audioManager, KEY_VOLUME_STEPS_ALARM,
+                    audioManager.STREAM_ALARM, volSteps(steps));
+         }
+    };
+
+    private static final SettingPref PREF_VOLUME_STEPS_DTMF = new SettingPref(
+            TYPE_SYSTEM, KEY_VOLUME_STEPS_DTMF, System.VOLUME_STEPS_DTMF,
+            VOLUME_STEPS_15,
+            VOLUME_STEPS_5, VOLUME_STEPS_7, VOLUME_STEPS_15,
+            VOLUME_STEPS_30, VOLUME_STEPS_45, VOLUME_STEPS_60) {
+        @Override
+        protected String getCaption(Resources res, int value) {
+            return volStepsCaption(res, value);
+        }
+
+        @Override
+        public void update(Context context) {
+            super.update(context);
+            final int steps = getInt(mType,
+                    context.getContentResolver(), mSetting, mDefault);
+            AudioManager audioManager = (AudioManager)
+                    context.getSystemService(Context.AUDIO_SERVICE);
+            updateVolumeSteps(audioManager, KEY_VOLUME_STEPS_DTMF,
+                    audioManager.STREAM_DTMF, volSteps(steps));
+        }
+    };
+
+    private static final SettingPref PREF_VOLUME_STEPS_MUSIC = new SettingPref(
+            TYPE_SYSTEM, KEY_VOLUME_STEPS_MUSIC, System.VOLUME_STEPS_MUSIC,
+            VOLUME_STEPS_15,
+            VOLUME_STEPS_5, VOLUME_STEPS_7, VOLUME_STEPS_15,
+            VOLUME_STEPS_30, VOLUME_STEPS_45, VOLUME_STEPS_60) {
+        @Override
+        protected String getCaption(Resources res, int value) {
+            return volStepsCaption(res, value);
+        }
+
+        @Override
+        public void update(Context context) {
+            super.update(context);
+            final int steps = getInt(mType,
+                    context.getContentResolver(), mSetting, mDefault);
+            AudioManager audioManager = (AudioManager)
+                    context.getSystemService(Context.AUDIO_SERVICE);
+            updateVolumeSteps(audioManager, KEY_VOLUME_STEPS_MUSIC,
+                    audioManager.STREAM_MUSIC, volSteps(steps));
+        }
+    };
+
+    private static final SettingPref PREF_VOLUME_STEPS_NOTIFICATION = new SettingPref(
+            TYPE_SYSTEM, KEY_VOLUME_STEPS_NOTIFICATION, System.VOLUME_STEPS_NOTIFICATION,
+            VOLUME_STEPS_7,
+            VOLUME_STEPS_5, VOLUME_STEPS_7, VOLUME_STEPS_15,
+            VOLUME_STEPS_30, VOLUME_STEPS_45, VOLUME_STEPS_60) {
+        @Override
+        protected String getCaption(Resources res, int value) {
+            return volStepsCaption(res, value);
+        }
+
+        @Override
+        public void update(Context context) {
+            super.update(context);
+            final int steps = getInt(mType,
+                    context.getContentResolver(), mSetting, mDefault);
+            AudioManager audioManager = (AudioManager)
+                    context.getSystemService(Context.AUDIO_SERVICE);
+            updateVolumeSteps(audioManager, KEY_VOLUME_STEPS_NOTIFICATION,
+                    audioManager.STREAM_NOTIFICATION, volSteps(steps));
+        }
+    };
+
+    private static final SettingPref PREF_VOLUME_STEPS_RING = new SettingPref(
+            TYPE_SYSTEM, KEY_VOLUME_STEPS_RING, System.VOLUME_STEPS_RING,
+            VOLUME_STEPS_7,
+            VOLUME_STEPS_5, VOLUME_STEPS_7, VOLUME_STEPS_15,
+            VOLUME_STEPS_30, VOLUME_STEPS_45, VOLUME_STEPS_60) {
+        @Override
+        protected String getCaption(Resources res, int value) {
+            return volStepsCaption(res, value);
+        }
+
+        @Override
+        public void update(Context context) {
+            super.update(context);
+            final int steps = getInt(mType,
+                    context.getContentResolver(), mSetting, mDefault);
+            AudioManager audioManager = (AudioManager)
+                    context.getSystemService(Context.AUDIO_SERVICE);
+            updateVolumeSteps(audioManager, KEY_VOLUME_STEPS_MUSIC,
+                    audioManager.STREAM_RING, volSteps(steps));
+        }
+    };
+
+    private static final SettingPref PREF_VOLUME_STEPS_SYSTEM = new SettingPref(
+            TYPE_SYSTEM, KEY_VOLUME_STEPS_SYSTEM, System.VOLUME_STEPS_SYSTEM,
+            VOLUME_STEPS_7,
+            VOLUME_STEPS_5, VOLUME_STEPS_7, VOLUME_STEPS_15,
+            VOLUME_STEPS_30, VOLUME_STEPS_45, VOLUME_STEPS_60) {
+        @Override
+        protected String getCaption(Resources res, int value) {
+            return volStepsCaption(res, value);
+        }
+
+        @Override
+        public void update(Context context) {
+            super.update(context);
+            final int steps = getInt(mType,
+                    context.getContentResolver(), mSetting, mDefault);
+            AudioManager audioManager = (AudioManager)
+                    context.getSystemService(Context.AUDIO_SERVICE);
+            updateVolumeSteps(audioManager, KEY_VOLUME_STEPS_SYSTEM,
+                    audioManager.STREAM_SYSTEM, volSteps(steps));
+        }
+    };
+
+    private static final SettingPref PREF_VOLUME_STEPS_VOICE_CALL = new SettingPref(
+            TYPE_SYSTEM, KEY_VOLUME_STEPS_VOICE_CALL, System.VOLUME_STEPS_VOICE_CALL,
+            VOLUME_STEPS_5,
+            VOLUME_STEPS_5, VOLUME_STEPS_7, VOLUME_STEPS_15,
+            VOLUME_STEPS_30, VOLUME_STEPS_45, VOLUME_STEPS_60) {
+        @Override
+        protected String getCaption(Resources res, int value) {
+            return volStepsCaption(res, value);
+        }
+
+        @Override
+        public void update(Context context) {
+            super.update(context);
+            final int steps = getInt(mType,
+                    context.getContentResolver(), mSetting, mDefault);
+            AudioManager audioManager = (AudioManager)
+                    context.getSystemService(Context.AUDIO_SERVICE);
+            updateVolumeSteps(audioManager, KEY_VOLUME_STEPS_VOICE_CALL,
+                    audioManager.STREAM_VOICE_CALL, volSteps(steps));
+        }
+    };
+
     private static final SettingPref[] PREFS = {
         PREF_DIAL_PAD_TONES,
         PREF_SCREEN_LOCKING_SOUNDS,
@@ -159,6 +329,13 @@ public class OtherSoundSettings extends SettingsPreferenceFragment implements In
         PREF_VIBRATE_ON_TOUCH,
         PREF_DOCK_AUDIO_MEDIA,
         PREF_EMERGENCY_TONE,
+        PREF_VOLUME_STEPS_ALARM,
+        PREF_VOLUME_STEPS_DTMF,
+        PREF_VOLUME_STEPS_MUSIC,
+        PREF_VOLUME_STEPS_NOTIFICATION,
+        PREF_VOLUME_STEPS_RING,
+        PREF_VOLUME_STEPS_SYSTEM,
+        PREF_VOLUME_STEPS_VOICE_CALL,
     };
 
     private final SettingsObserver mSettingsObserver = new SettingsObserver();
@@ -251,4 +428,51 @@ public class OtherSoundSettings extends SettingsPreferenceFragment implements In
             return rt;
         }
     };
+
+    // === Volume Steps ===
+
+    private static String volStepsCaption(Resources res, int value) {
+        switch(value) {
+            case VOLUME_STEPS_5:
+                return res.getString(R.string.volume_steps_5);
+            case VOLUME_STEPS_7:
+                return res.getString(R.string.volume_steps_7);
+            case VOLUME_STEPS_15:
+                return res.getString(R.string.volume_steps_15);
+            case VOLUME_STEPS_30:
+                return res.getString(R.string.volume_steps_30);
+            case VOLUME_STEPS_45:
+                return res.getString(R.string.volume_steps_45);
+            case VOLUME_STEPS_60:
+                return res.getString(R.string.volume_steps_60);
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    private static int volSteps(int value) {
+        switch(value) {
+            case VOLUME_STEPS_5:
+                return 5;
+            case VOLUME_STEPS_7:
+                return 7;
+            case VOLUME_STEPS_15:
+                return 15;
+            case VOLUME_STEPS_30:
+                return 30;
+            case VOLUME_STEPS_45:
+                return 45;
+            case VOLUME_STEPS_60:
+                return 60;
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    private static void updateVolumeSteps(AudioManager audioManager,
+            String settingsKey, int streamType, int steps){
+        //Change the setting live
+        audioManager.setStreamMaxVolume(streamType, steps);
+        Log.i(TAG, "Volume steps:" + settingsKey + "" + String.valueOf(steps));
+    }
 }


### PR DESCRIPTION
This amounts to a complete rewrite of the volume steps Settings
app implementation. Settings is entirely different from the same
in KitKat, thus the ultimate need for a rewrite.

Still, the original author, Meticulus theonejohnnyd@gmail.com,
deserves credit for the original volume steps feature. See:
http://review.pac-rom.com/#/c/467 for the kitkat commit.

PS2: just fixing the commit message to match the other in the set.
PS3: Move to PAC settings
PS4: Never mind
PS5: Rebase
PS6: Move to PAC Settings table
PS7: Add a preference category
PS8: Remove unnecessary commented code.

Change-Id: I03f72867de579c7fb8f2932627f89ea2e94c1613
