### PR TITLE
show broken recent enabled by default

### DIFF
--- a/res/xml/recent_panel_settings.xml
+++ b/res/xml/recent_panel_settings.xml
@@ -21,7 +21,7 @@
         <SwitchPreference
             android:key="use_slim_recents"
             android:title="@string/use_slim_recents_title"
-            android:defaultValue="false" />
+            android:defaultValue="true" />
 
         <SwitchPreference
             android:key="only_show_running_tasks"


### PR DESCRIPTION
this is enabled by default on a clean flash but the switch is not so those wanting to use the regular aosp recent apps have to enable then disable this to make them work.
